### PR TITLE
Add ajax to messages

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -3,6 +3,7 @@ $(function(){
   e.preventDefault();
    let formData = new FormData(this);
    let url = $(this).attr('action');
+   console.log(this);
    $.ajax({
      url: url,
      type: "POST",
@@ -11,6 +12,12 @@ $(function(){
      processData: false,
      contentType: false
    })
+  .done(function(message){
+    console.log(message);  
+  })
+  .fail(function(){
+
+  })
  })
 });
 

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -20,7 +20,7 @@ $(function(){
   e.preventDefault();
    let formData = new FormData(this);
    let url = $(this).attr('action');
-   console.log(this);
+   
    $.ajax({
      url: url,
      type: "POST",
@@ -32,7 +32,7 @@ $(function(){
   .done(function(message){
     let html = buildMessage(message);
     $('.messages').append(html)
-    $('#message_content').val('')
+    $('#message_content')[0].reset();
     $('.submit-btn').removeAttr('disabled');
     $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight},300);
   })

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,16 @@
+$(function(){
+ $('#new_message').on('submit', function(e){
+  e.preventDefault();
+   let formData = new FormData(this);
+   let url = $(this).attr('action');
+   $.ajax({
+     url: url,
+     type: "POST",
+     data: formData,
+     dataType: 'json',
+     processData: false,
+     contentType: false
+   })
+ })
+});
+

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,6 +1,7 @@
 $(function(){
 
   function buildMessage(message){
+    image = message.image.url ? `<img src=${message.image.url}>` : "";
     let html = `<div class="message__upper-info__talker">
                 ${message.user_name}
                 </div>
@@ -9,7 +10,9 @@ $(function(){
                 </div>
                 <p class="message__text">
                 ${message.content}
-                </p>`
+                </p>
+                ${image}`
+                
     return html;
   }
 
@@ -30,12 +33,11 @@ $(function(){
     let html = buildMessage(message);
     $('.messages').append(html)
     $('#message_content').val('')
-    $('#.submit-btn').removeAttr('disabled');
+    $('.submit-btn').removeAttr('disabled');
+    $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight},300);
   })
   .fail(function(){
     alert('エラー');
-    
-
   })
  })
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,4 +1,18 @@
 $(function(){
+
+  function buildMessage(message){
+    let html = `<div class="message__upper-info__talker">
+                ${message.user_name}
+                </div>
+                <div class="message__upper-info__date">
+                ${message.created_at}
+                </div>
+                <p class="message__text">
+                ${message.content}
+                </p>`
+    return html;
+  }
+
  $('#new_message').on('submit', function(e){
   e.preventDefault();
    let formData = new FormData(this);
@@ -13,9 +27,14 @@ $(function(){
      contentType: false
    })
   .done(function(message){
-    console.log(message);  
+    let html = buildMessage(message);
+    $('.messages').append(html)
+    $('#message_content').val('')
+    $('#.submit-btn').removeAttr('disabled');
   })
   .fail(function(){
+    alert('エラー');
+    
 
   })
  })

--- a/app/assets/stylesheets/_messages.scss
+++ b/app/assets/stylesheets/_messages.scss
@@ -4,13 +4,13 @@
 
 .messages{
   height: calc(100vh - 190px);
-  padding: 20px 20px;
+  padding: 20px 20px 20px 40px;
   background-color: #fafafa;
   overflow: scroll;
 
   .message{
     padding-bottom: 0px;
-    
+    height: 100%;
 
     &__upper-info{
       display: flex;

--- a/app/assets/stylesheets/_reset.scss
+++ b/app/assets/stylesheets/_reset.scss
@@ -54,6 +54,8 @@ table {
 fieldset,
 img {
 	border:0;
+	display: block;
+	margin-bottom: 20px;
 }
 /*
 	TODO think about hanlding inheritence differently, maybe letting IE6 fail a bit...

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,10 +9,12 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
       if @message.save
-        redirect_to group_messages_path(@group), notice: 'メッセージが送信されました。'
+        respond_to do |format| 
+          format.html{redirect_to group_messages_path(params[:group_id])} #notice: 'メッセージが送信されました。'
+          format.json
+        end
       else
-        @messages = @group.messages.includes(:user)
-        flash.now[:alert] = 'メッセージを入力してください。'
+        flash[:alert] = 'メッセージを入力してください。'
         render :index
       end      
     end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -3,7 +3,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   # include CarrierWave::RMagick
   include CarrierWave::MiniMagick
   
-  process resize_to_fit: [300, 300]
+  process resize_to_fit: [250, 250]
 
   # Choose what kind of storage to use for this uploader:
   storage :file

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,1 +1,5 @@
-json.text @message.text
+  json.(@message, :content, :image)
+  json.user_name  @message.user.name
+  json.created_at @message.created_at
+  json.group_id   @message.group_id
+  json.id         @message.id

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,1 @@
+json.text @message.text

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,6 @@ module ChatSpace
         g.test_framework false
       end
       config.i18n.default_locale = :ja
+      config.time_zone = 'Tokyo'
     end
 end


### PR DESCRIPTION
### Why
chatspaceを非同期通信にして、投稿毎にリロードをしないようにするため。
データのやり取りを少なくし更新速度を早めるため。
また、投稿時に自動的に投稿した部分までオートスクロールを実装し、ユーザーがスクローリングする手間を省く。

### What

[dfb1eac](https://github.com/mf-Q/chat-space/commit/dfb1eacaafb3145afcb23f3d3b718a87e0f88cea)
ajaxを組み込み、イベントが発火するところまで確認。

[5e28690](https://github.com/mf-Q/chat-space/commit/5e286905cf9142542acb2532c2be86c76fc25e5c)
create.json.jbuilderを追加してcontroller編集、consoleで情報が得られているのを確認。

[3c200a9](https://github.com/mf-Q/chat-space/commit/3c200a9b61b2b898b69e2465343f6e166b84ce33)
送信したらメッセージ欄にhtmlの形式で情報が反映される。
送信後、フォーム内の文字が自動で消える。
送信ボタンのdisabled仕様を解除するコードを追加。
送信できない時のエラーメッセージ追加。

[09ee7ca](https://github.com/mf-Q/chat-space/commit/09ee7cac3b36dd220469bac6d65e283cebfaf522)
オートスクロールを実装。
画像投稿時に表示がおかしかったのでscssを修正とレイアウト少し調整。
表示時のタイムゾーンを日本時間にするのにconfig/application.rbにconfig.time_zone = 'Tokyo'追記。

以下、挙動をgifにしたのを貼っておきます。ご照査ください。
https://gyazo.com/collections/f9c541f6bafcae4770a7549726e31b46

よろしくお願いいたします。

