### PR TITLE
Work on incremental search

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.language": "en,en-GB,en-US"
+}

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,6 +1,7 @@
-$(function() {
+$(document).on('turbolinks:load', function(){
 
   let search_list = $("#user-search-result");
+  let add_list = $(".user");
 
   function buildUserresult(user){
     let html =`<div class="chat-group-user clearfix">
@@ -10,6 +11,17 @@ $(function() {
     search_list.append(html);
   }
   
+  function addMember_remove(user_id, user_name) {
+    let html = `<div class='chat-group-user clearfix js-chat-member', id="chat-group-user-${ user_id }">
+                  <input name='group[user_ids][]' type='hidden' value='${ user_id }' >
+                  <p class='chat-group-user__name'>${ user_name }</p>
+                  <p class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>削除</p>
+                </div>`
+    add_list.append(html);
+  }
+
+
+
   function buildErrorMsg(msg){
     let html = `<div class="chat-group-user clearfix">
                 <p class="chat-group-user__name">${msg}</p>
@@ -21,11 +33,16 @@ $(function() {
   $("#user-search-field").on("keyup", function(e) {
     e.preventDefault();
     let input = $("#user-search-field").val();
-    
+    let group_id = $('.chat__group_id').val();
+    // いまいるユーザーの配列の箱をつくる
+
+    //配列にユーザーをあたいを入れる
+
     $.ajax({
       type: 'GET',
       url: '/users',
-      data: { keyword: input },
+      data: { keyword: input, group_id: group_id },
+       //配列のぱらむすを渡す
       dataType: 'json'    
      })
 
@@ -34,9 +51,10 @@ $(function() {
       $('#user-search-result').empty();
     }
     else {
-      if(users.length !== 0){
+      if(input.length !== 0){
       $('#user-search-result').empty();
       users.forEach(function(user){
+        if(user.name !== $('.chat-group-user__name').val())         // 一度検索された人を出さないようにする。
         buildUserresult(user);
       });
     }
@@ -52,4 +70,17 @@ $(function() {
         });
 
   })
+
+  $(document).on("click", ".user-search-add", function () {
+    let user_id = $(this).data("user-id");
+    let user_name = $(this).data("user-name");
+    $(this).parent().remove();
+    addMember_remove(user_id, user_name);
+  })
+
+  $(document).on("click", ".user-search-remove", function () {
+    $(this).parent().remove();
+  })
+
 });
+

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,0 +1,7 @@
+$(function() {
+  $("#user-search-field").on("keyup", function() {
+    var input = $("#user-search-field").val();
+    console.log(input);
+
+  });
+});

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,7 +1,55 @@
 $(function() {
-  $("#user-search-field").on("keyup", function() {
-    var input = $("#user-search-field").val();
-    console.log(input);
 
-  });
+  let search_list = $("#user-search-result");
+
+  function buildUserresult(user){
+    let html =`<div class="chat-group-user clearfix">
+              <p class="chat-group-user__name">${user.name}</p>
+              <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id=${user.id} data-user-name=${user.name}>追加</div>
+              </div>`
+    search_list.append(html);
+  }
+  
+  function buildErrorMsg(msg){
+    let html = `<div class="chat-group-user clearfix">
+                <p class="chat-group-user__name">${msg}</p>
+                </div>`
+    search_list.append(html);
+  }
+
+
+  $("#user-search-field").on("keyup", function(e) {
+    e.preventDefault();
+    let input = $("#user-search-field").val();
+    
+    $.ajax({
+      type: 'GET',
+      url: '/users',
+      data: { keyword: input },
+      dataType: 'json'    
+     })
+
+    .done(function(users){
+    if(input.length == 0){
+      $('#user-search-result').empty();
+    }
+    else {
+      if(users.length !== 0){
+      $('#user-search-result').empty();
+      users.forEach(function(user){
+        buildUserresult(user);
+      });
+    }
+    else{
+      $('#user-search-result').empty();
+        buildErrorMsg('一致するユーザーが見つかりませんでした');
+    }
+  }
+      })
+
+    .fail(function(){
+      alert('エラー');
+        });
+
+  })
 });

--- a/app/assets/stylesheets/_group.scss
+++ b/app/assets/stylesheets/_group.scss
@@ -55,6 +55,7 @@ li {
   &__action-btn {
     display: inline-block;
     padding: 12px 20px;
+    margin-top: 20px;
     color: #fff;
     background-color: #38aef0;
     border: 0;

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -7,6 +7,7 @@ class GroupsController < ApplicationController
   def new
     @group = Group.new
     @group.users << current_user
+    @members = @group.users 
   end
 
   def create
@@ -34,5 +35,6 @@ class GroupsController < ApplicationController
 
     def set_group
       @group = Group.find(params[:id])
+      @members = @group.users 
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,14 @@ def edit
 end
 
 def index
-  @users = User.where('name LIKE(?)',  "%#{params[:keyword]}%")
+  if params[:group_id].present?
+    @group = Group.find(params[:group_id])
+    @ids = @group.users.ids
+    @users = User.where.not(id: @ids).where('(name LIKE(?)) and (id != ?)', "%#{params[:keyword]}%", "#{current_user.id}")
+    # ↑カレントゆーざーアイディーだけでなくぜんぶノットの対象にする
+  else
+    @users = User.where('(name LIKE(?)) and (id != ?)', "%#{params[:keyword]}%", "#{current_user.id}")
+  end
   respond_to do |format|
     format.html
     format.json
@@ -24,5 +31,10 @@ private
 def user_params
   params.require(:user).permit(:name, :email)
 end
+
+# def xxx
+# あじゃっくすでわたってきた配列にカレントユーザーIDをいれて、あたらに配列を再生成する
+# その再生性した配列をノットで省く
+# end
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,7 @@ def edit
 end
 
 def index
+  @users = User.where('name LIKE(?)',  "%#{params[:keyword]}%")
   respond_to do |format|
     format.html
     format.json

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,13 @@ class UsersController < ApplicationController
 def edit
 end
 
+def index
+  respond_to do |format|
+    format.html
+    format.json
+  end
+end
+
 def update
   if current_user.update(user_params)
     redirect_to root_path

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -12,14 +12,15 @@
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
   .chat-group-form__field.clearfix
     / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+  .chat-group-form__field--left
+    %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+  .chat-group-form__field--right
+    .chat-group-form__search.clearfix
+      %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+      #user-search-result  
+    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
-      %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-  .chat-group-form__field.clearfix
-    .chat-group-form__field--left
-    .chat-group-form__field--right
+    
       = f.submit class: 'chat-group-form__action-btn'

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -10,10 +10,11 @@
       = f.label "グループ名", class: 'chat-group-form__label' 
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
+      = f.hidden_field :id, class: "chat__group_id", value: group.id
   .chat-group-form__field.clearfix
     / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
   .chat-group-form__field--left
-    %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+    %label.chat-group-form__label{:for => "user-search-field"} チャットメンバーを追加
   .chat-group-form__field--right
     .chat-group-form__search.clearfix
       %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
@@ -21,6 +22,24 @@
     / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat-group-users"} チャットメンバー
+      
+  
     .chat-group-form__field--right
+      .chat-group-user.clearfix.js-chat-member
+        %input{name: "group[user_ids][]", type: "hidden", value: "#{current_user.id}"}
+        %p.chat-group-user__name #{current_user.name}
     
+    .chat-group-form__field--right.user
+      - group.users.each do |user|
+        - if user.id != current_user.id 
+          .chat-group-user.clearfix.js-chat-member
+            %input{name: "group[user_ids][]", type: "hidden", value: "#{user.id}"}
+            %p.chat-group-user__name
+              = user.name
+              %p.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn 削除
+            
+    .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+    .chat-group-form__field--right
       = f.submit class: 'chat-group-form__action-btn'

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,3 @@
+json.array! @users do |user|
+
+end

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,3 +1,4 @@
 json.array! @users do |user|
 json.name   user.name
+json.id     user.id
 end

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,3 +1,3 @@
 json.array! @users do |user|
-
+json.name   user.name
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
 root 'groups#index'
-resources :users,   only:  [:index, :edit, :update]
+resources :users,   only:  [:index, :edit, :update, :show]
 resources :groups,  only:  [:new, :create, :edit, :update] do
   resources :messages, only:  [:index, :create]
   end


### PR DESCRIPTION
##Why
ユーザー検索を容易にするように、インクリメンタルサーチを追加。


##What
インクリメンタルサーチをユーザー検索ボックスに実装。
検索にかかったユーザーをメンバーとして追加できるようにする。
また、既存メンバーを削除できるように削除ボタンを追加。
その際に、ログイン中のカレントユーザーは既存のチャットメンバーとして表示され削除不可、及びインクリメンタルサーチには表示されないようにした。

[9d0d963](https://github.com/mf-Q/chat-space/commit/9d0d963954fc12beaba40fa75b0b291b19ec6cd2)
インクリメンタルサーチに使うuser.jsとindex.json.jbuilderを作成、userのroutesにindexを追加、contorollerでindexの設定をした。テキストフィールドを作成時、登録ボタンのmargine-topを追加、consoleにてクリックイベントの確認済み

[e1487d8](https://github.com/mf-Q/chat-space/commit/e1487d89cc261703667dffbb279e53302462932d)
グループ新規作成画面での登録済みユーザーの選択ができるようになった。

[3f62568](https://github.com/mf-Q/chat-space/commit/3f6256899144e47541816af03355d26fa441bda6)
インクリメンタルサーチを追加して、チャットメンバーのユーザー追加と削除をできるようにした。

以下、インクリメンタルサーチ挙動と、グループ新規制作画面と編集画面の挙動、更新時に既存ユーザーがきちんと残って更新される状態をgifにしたのを添付しておきますので、ご照査ください。
よろしくおねがいします。
https://gyazo.com/collections/051c2d5a3e0f7a4867246372752f1b9d