### PR TITLE
add automatic update system：自動更新を実装しました。

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,19 +2,23 @@ $(function(){
 
   function buildMessage(message){
     image = message.image.url ? `<img src=${message.image.url}>` : "";
-    let html = `<div class="message__upper-info__talker">
-                ${message.user_name}
-                </div>
-                <div class="message__upper-info__date">
-                ${message.created_at}
-                </div>
-                <p class="message__text">
-                ${message.content}
-                </p>
-                ${image}`
+    let html = `<div class="auto clearfix" data-message-id=${message.id}>
+                  <div class="message__upper-info__talker">
+                  ${message.user_name}
+                  </div>
+                  <div class="message__upper-info__date">
+                  ${message.created_at}
+                  </div>
+                  <p class="message__text">
+                  ${message.content}
+                  </p>
+                  ${image}
+                </div>`
                 
     return html;
   }
+
+
 
  $('#new_message').on('submit', function(e){
   e.preventDefault();
@@ -32,7 +36,7 @@ $(function(){
   .done(function(message){
     let html = buildMessage(message);
     $('.messages').append(html)
-    $('#message_content')[0].reset();
+    $('#new_message')[0].reset();
     $('.submit-btn').removeAttr('disabled');
     $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight},300);
   })
@@ -40,5 +44,36 @@ $(function(){
     alert('エラー');
   })
  })
+
+  let reloadMessages = function() {
+    if (window.location.href.match(/\/groups\/\d+\/messages/)){       //グループメッセージのページだけで自動更新させる
+    //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+      let last_message_id = $('.auto:last').data("message-id");
+    console.log(last_message_id)
+    $.ajax({
+      //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
+      url: "api/messages",
+      //ルーティングで設定した通りhttpメソッドをgetに指定
+      type: 'get',
+      dataType: 'json',
+      //dataオプションでリクエストに値を含める
+      data: {id: last_message_id}
+    })
+
+    .done(function(messages) {
+      let insertHTML ='';
+      messages.forEach(function (message) {
+      insertHTML = buildMessage(message);
+      $('.messages').append(insertHTML); 
+        })
+      $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+      })
+    .fail(function() {
+      alert('更新に失敗しました');
+    });
+   }
+  };
+  setInterval(reloadMessages, 5000);
+
 });
 

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,8 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id]) #ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}") #グループ内のメッセージの中から、params[:last_id]が最も大きいid（新しいってこと）がないかMessageを検索して、@messagesに入れる。
+
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content      message.content
+  json.image        message.image
+  json.created_at   message.created_at.strftime("%Y/%m/%d %H:%M")
+  json.user_name    message.user.name
+  json.id           message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,8 +1,9 @@
-.message__upper-info__talker
-  = message.user.name
-.message__upper-info__date
-  = message.created_at.strftime("%Y/%m/%d %H:%M")
-- if message.content.present?
-  %p.message__text
-    = message.content
-= image_tag message.image.url, class: 'lower-message__image' if message.image.present?
+%div.auto.clearfix{"data-message-id": "#{message.id}" }
+  .message__upper-info__talker
+    = message.user.name
+  .message__upper-info__date
+    = message.created_at.strftime("%Y/%m/%d %H:%M")
+  - if message.content.present?
+    %p.message__text
+      = message.content
+  = image_tag message.image.url, class: 'lower-message__image' if message.image.present?

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,5 @@
   json.(@message, :content, :image)
   json.user_name  @message.user.name
-  json.created_at @message.created_at
+  json.created_at @message.created_at.strftime("%Y/%m/%d %H:%M")
   json.group_id   @message.group_id
   json.id         @message.id

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -3,4 +3,5 @@
   = render 'shared/chat-main'
 .messages
   = render @messages
+.form
   = render 'shared/form'

--- a/app/views/shared/_form.html.haml
+++ b/app/views/shared/_form.html.haml
@@ -1,9 +1,8 @@
-.form
-  .new_message
-  = form_for [@group, @message] do |f|
-    = f.text_field :content, class: 'input-box__text', placeholder:"type a message"
-    = f.label :image, {for: "upload-icon"} do 
-      .input-box__text__image
-        = fa_icon 'image'
-        = f.file_field :image, class:'input-box__text__image__file', id: "upload-icon"
-    = f.submit 'Send', class:'submit-btn'
+.new_message
+= form_for [@group, @message] do |f|
+  = f.text_field :content, class: 'input-box__text', placeholder:"type a message"
+  = f.label :image, {for: "upload-icon"} do 
+    .input-box__text__image
+      = fa_icon 'image'
+      = f.file_field :image, class:'input-box__text__image__file', id: "upload-icon"
+  = f.submit 'Send', class:'submit-btn'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,8 @@ root 'groups#index'
 resources :users,   only:  [:index, :edit, :update, :show]
 resources :groups,  only:  [:new, :create, :edit, :update] do
   resources :messages, only:  [:index, :create]
+  namespace :api do
+    resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
##Why
他の人がチャットした場合、リロードせずに自動でその内容が表示されるようにする。
チャットルームでは誰がどのタイミングで書き込むかわからないので、常に最新の情報を表示できたほうがユーザーフレンドリーであるため。

##What
自動更新を実装しました。
Aのウィンドウで入力したものが、Bのウィンドウでも表示されるように５秒毎に自動で更新されます。
その際に、最新の書き込み位置にスクロールをするように設定しました。
また、自動更新がチャットページ以外で作動しないように制御しております。

以下、自動更新時に最新コメントに移動する挙動とテキスト、画像、両方の投稿において自動更新する挙動をgifにて添付しますので、ご精査ください。
よろしくお願いいたします。
https://gyazo.com/collections/6f237f109b914abe084d5087b1006f12